### PR TITLE
Refactor codebase to increase consistency and adhere to Google styleguide

### DIFF
--- a/capstone/src/main/java/com/google/sps/data/BusinessProfile.java
+++ b/capstone/src/main/java/com/google/sps/data/BusinessProfile.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.data;
 
 // This stores information about business owner user profile page.

--- a/capstone/src/main/java/com/google/sps/data/User.java
+++ b/capstone/src/main/java/com/google/sps/data/User.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.data;
 
 /** Individual user login data. */

--- a/capstone/src/main/java/com/google/sps/data/UserProfile.java
+++ b/capstone/src/main/java/com/google/sps/data/UserProfile.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.data;
 
 // This stores information about non-business owner user profile page.

--- a/capstone/src/main/java/com/google/sps/servlets/authentication/LoginServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/authentication/LoginServlet.java
@@ -1,4 +1,20 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.servlets.authentication;
+
+import static com.google.sps.data.ProfileDatastoreUtil.PROFILE_TASK_NAME;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -39,7 +55,7 @@ public class LoginServlet extends HttpServlet {
 
     if (userService.isUserLoggedIn()) {
       String userId = userService.getCurrentUser().getUserId();
-      String keyString = KeyFactory.createKeyString("UserProfile", userId);
+      String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, userId);
       Key userKey = KeyFactory.stringToKey(keyString);
 
       try {

--- a/capstone/src/main/java/com/google/sps/servlets/authentication/LogoutServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/authentication/LogoutServlet.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.servlets.authentication;
 
 import java.io.IOException;

--- a/capstone/src/main/java/com/google/sps/servlets/authentication/NewUserServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/authentication/NewUserServlet.java
@@ -1,4 +1,27 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.servlets.authentication;
+
+import static com.google.sps.data.ProfileDatastoreUtil.ANONYMOUS_NAME;
+import static com.google.sps.data.ProfileDatastoreUtil.BIO_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.IS_BUSINESS_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.LOCATION_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.NAME_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.NO;
+import static com.google.sps.data.ProfileDatastoreUtil.NULL_STRING;
+import static com.google.sps.data.ProfileDatastoreUtil.PROFILE_TASK_NAME;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -18,14 +41,6 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/check_new_user")
 public class NewUserServlet extends HttpServlet {
 
-  private static final String IS_BUSINESS_PROPERTY = "isBusiness";
-  private static final String NAME_PROPERTY = "name";
-  private static final String LOCATION_PROPERTY = "location";
-  private static final String BIO_PROPERTY = "bio";
-  private static final String ANONYMOUS_NAME = "Anonymous";
-  private static final String DEFAULT = "";
-  private static final String NO = "No";
-
   UserService userService = UserServiceFactory.getUserService();
 
   DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
@@ -35,18 +50,18 @@ public class NewUserServlet extends HttpServlet {
     // Create a key from user sign in ID and check if it's in the database.
     String userId = userService.getCurrentUser().getUserId();
 
-    String keyString = KeyFactory.createKeyString("UserProfile", userId);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, userId);
     Key userKey = KeyFactory.stringToKey(keyString);
 
     try {
       Entity entity = datastore.get(userKey);
     } catch (EntityNotFoundException e) {
       // Add user to database with default values.
-      Entity userEntity = new Entity("UserProfile", userId);
+      Entity userEntity = new Entity(PROFILE_TASK_NAME, userId);
       userEntity.setProperty(IS_BUSINESS_PROPERTY, NO);
       userEntity.setProperty(NAME_PROPERTY, ANONYMOUS_NAME);
-      userEntity.setProperty(LOCATION_PROPERTY, DEFAULT);
-      userEntity.setProperty(BIO_PROPERTY, DEFAULT);
+      userEntity.setProperty(LOCATION_PROPERTY, NULL_STRING);
+      userEntity.setProperty(BIO_PROPERTY, NULL_STRING);
 
       datastore.put(userEntity);
     }

--- a/capstone/src/main/java/com/google/sps/servlets/business/BusinessServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/business/BusinessServlet.java
@@ -1,4 +1,29 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.servlets;
+
+import static com.google.sps.data.ProfileDatastoreUtil.ABOUT_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.BIO_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.IS_BUSINESS_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.LOCATION_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.NAME_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.NO;
+import static com.google.sps.data.ProfileDatastoreUtil.PROFILE_TASK_NAME;
+import static com.google.sps.data.ProfileDatastoreUtil.STORY_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.SUPPORT_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.YES;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -19,15 +44,6 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet responsible for showing a business user profile. */
 @WebServlet("/business/*")
 public class BusinessServlet extends HttpServlet {
-
-  private static final String IS_BUSINESS_PROPERTY = "isBusiness";
-  private static final String NAME_PROPERTY = "name";
-  private static final String LOCATION_PROPERTY = "location";
-  private static final String BIO_PROPERTY = "bio";
-  private static final String STORY_PROPERTY = "story";
-  private static final String ABOUT_PROPERTY = "about";
-  private static final String SUPPORT_PROPERTY = "support";
-
   UserService userService = UserServiceFactory.getUserService();
 
   DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
@@ -45,7 +61,7 @@ public class BusinessServlet extends HttpServlet {
 
     String userId = pathSegments[1];
 
-    String keyString = KeyFactory.createKeyString("UserProfile", userId);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, userId);
     Key userKey = KeyFactory.stringToKey(keyString);
     Entity entity;
 
@@ -64,7 +80,7 @@ public class BusinessServlet extends HttpServlet {
         entity.hasProperty(IS_BUSINESS_PROPERTY)
             ? (String) entity.getProperty(IS_BUSINESS_PROPERTY)
             : "";
-    if (!isBusiness.equals("Yes")) {
+    if (!isBusiness.equals(YES)) {
       response.sendError(
           HttpServletResponse.SC_NOT_FOUND,
           "The profile you were looking for was not found in our records!");
@@ -117,10 +133,10 @@ public class BusinessServlet extends HttpServlet {
     }
 
     // Update properties in datastore.
-    Entity businessEntity = new Entity("UserProfile", id);
+    Entity businessEntity = new Entity(PROFILE_TASK_NAME, id);
 
     // If user is a non-business owner, return error.
-    if (getParam(IS_BUSINESS_PROPERTY, request).equals("No")) {
+    if (getParam(IS_BUSINESS_PROPERTY, request).equals(NO)) {
       response.sendError(
           HttpServletResponse.SC_NOT_FOUND, "You don't have permission to perform this action!");
       return;

--- a/capstone/src/main/java/com/google/sps/servlets/business/BusinessesServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/business/BusinessesServlet.java
@@ -14,6 +14,16 @@
 
 package com.google.sps.servlets;
 
+import static com.google.sps.data.ProfileDatastoreUtil.ABOUT_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.BIO_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.IS_BUSINESS_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.LOCATION_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.NAME_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.PROFILE_TASK_NAME;
+import static com.google.sps.data.ProfileDatastoreUtil.STORY_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.SUPPORT_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.YES;
+
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
@@ -35,22 +45,13 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet responsible for listing all business profiles. */
 @WebServlet("/businesses")
 public class BusinessesServlet extends HttpServlet {
-
-  private static final String IS_BUSINESS_PROPERTY = "isBusiness";
-  private static final String NAME_PROPERTY = "name";
-  private static final String LOCATION_PROPERTY = "location";
-  private static final String BIO_PROPERTY = "bio";
-  private static final String STORY_PROPERTY = "story";
-  private static final String ABOUT_PROPERTY = "about";
-  private static final String SUPPORT_PROPERTY = "support";
-
   DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     // Query profile entities from datastore.
-    Filter propertyFilter = new FilterPredicate(IS_BUSINESS_PROPERTY, FilterOperator.EQUAL, "Yes");
-    Query query = new Query("UserProfile").setFilter(propertyFilter);
+    Filter propertyFilter = new FilterPredicate(IS_BUSINESS_PROPERTY, FilterOperator.EQUAL, YES);
+    Query query = new Query(PROFILE_TASK_NAME).setFilter(propertyFilter);
 
     PreparedQuery results = datastore.prepare(query);
 

--- a/capstone/src/main/java/com/google/sps/servlets/comments/CommentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/comments/CommentServlet.java
@@ -14,12 +14,12 @@
 
 package com.google.sps.servlets;
 
-import static com.google.sps.data.CommentDatastore.BUSINESS_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastore.COMMENT_ENTITY_NAME;
-import static com.google.sps.data.CommentDatastore.CONTENT_PROPERTY;
-import static com.google.sps.data.CommentDatastore.PARENT_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastore.TIMESTAMP_PROPERTY;
-import static com.google.sps.data.CommentDatastore.USER_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.BUSINESS_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.COMMENT_TASK_NAME;
+import static com.google.sps.data.CommentDatastoreUtil.CONTENT_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.PARENT_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.TIMESTAMP_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.USER_ID_PROPERTY;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -78,7 +78,7 @@ public class CommentServlet extends HttpServlet {
   }
 
   private Entity buildCommentEntity(HttpServletRequest request) {
-    Entity commentEntity = new Entity(COMMENT_ENTITY_NAME);
+    Entity commentEntity = new Entity(COMMENT_TASK_NAME);
 
     REQUIRED_PARAMETERS.forEach(
         parameter -> commentEntity.setProperty(parameter, request.getParameter(parameter)));

--- a/capstone/src/main/java/com/google/sps/servlets/comments/CommentsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/comments/CommentsServlet.java
@@ -14,12 +14,12 @@
 
 package com.google.sps.servlets;
 
-import static com.google.sps.data.CommentDatastore.BUSINESS_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastore.COMMENT_ENTITY_NAME;
-import static com.google.sps.data.CommentDatastore.PARENT_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastore.TIMESTAMP_PROPERTY;
-import static com.google.sps.data.CommentDatastore.USER_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastore.generateComment;
+import static com.google.sps.data.CommentDatastoreUtil.BUSINESS_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.COMMENT_TASK_NAME;
+import static com.google.sps.data.CommentDatastoreUtil.PARENT_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.TIMESTAMP_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.USER_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.generateComment;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -102,7 +102,7 @@ public class CommentsServlet extends HttpServlet {
   private List<Entity> runCommentsQuery(String filterProperty, String filterValue)
       throws IllegalArgumentException {
     Query query =
-        new Query(COMMENT_ENTITY_NAME)
+        new Query(COMMENT_TASK_NAME)
             .setFilter(buildFilter(filterProperty, filterValue))
             .addSort(TIMESTAMP_PROPERTY, SortDirection.DESCENDING);
     return datastore.prepare(query).asList(FetchOptions.Builder.withLimit(COMMENT_LIMIT));

--- a/capstone/src/main/java/com/google/sps/servlets/profile/ProfileServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/profile/ProfileServlet.java
@@ -1,4 +1,25 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.servlets.profile;
+
+import static com.google.sps.data.ProfileDatastoreUtil.BIO_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.IS_BUSINESS_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.LOCATION_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.NAME_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.PROFILE_TASK_NAME;
+import static com.google.sps.data.ProfileDatastoreUtil.YES;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -19,10 +40,6 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet responsible for showing a non-business user profile. */
 @WebServlet("/profile/*")
 public class ProfileServlet extends HttpServlet {
-  private static final String IS_BUSINESS_PROPERTY = "isBusiness";
-  private static final String NAME_PROPERTY = "name";
-  private static final String LOCATION_PROPERTY = "location";
-  private static final String BIO_PROPERTY = "bio";
 
   UserService userService = UserServiceFactory.getUserService();
 
@@ -41,7 +58,7 @@ public class ProfileServlet extends HttpServlet {
 
     String userId = pathSegments[1];
 
-    String keyString = KeyFactory.createKeyString("UserProfile", userId);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, userId);
     Key userKey = KeyFactory.stringToKey(keyString);
     Entity entity;
 
@@ -60,7 +77,7 @@ public class ProfileServlet extends HttpServlet {
         entity.hasProperty(IS_BUSINESS_PROPERTY)
             ? (String) entity.getProperty(IS_BUSINESS_PROPERTY)
             : "";
-    if (isBusiness.equals("Yes")) {
+    if (isBusiness.equals(YES)) {
       response.sendError(
           HttpServletResponse.SC_NOT_FOUND,
           "The profile you were looking for was not found in our records!");
@@ -106,10 +123,10 @@ public class ProfileServlet extends HttpServlet {
     String id = userService.getCurrentUser().getUserId();
 
     // Update properties in datastore.
-    Entity profileEntity = new Entity("UserProfile", id);
+    Entity profileEntity = new Entity(PROFILE_TASK_NAME, id);
 
     // If user is a business owner, return error.
-    if (getParam(IS_BUSINESS_PROPERTY, request).equals("Yes")) {
+    if (getParam(IS_BUSINESS_PROPERTY, request).equals(YES)) {
       response.sendError(
           HttpServletResponse.SC_NOT_FOUND, "You don't have permission to perform this action!");
       return;

--- a/capstone/src/main/java/com/google/sps/util/CommentDatastoreUtil.java
+++ b/capstone/src/main/java/com/google/sps/util/CommentDatastoreUtil.java
@@ -16,8 +16,8 @@ package com.google.sps.data;
 
 import com.google.appengine.api.datastore.Entity;
 
-public final class CommentDatastore {
-  public static final String COMMENT_ENTITY_NAME = "Comment";
+public final class CommentDatastoreUtil {
+  public static final String COMMENT_TASK_NAME = "Comment";
 
   public static final String CONTENT_PROPERTY = "content";
   public static final String TIMESTAMP_PROPERTY = "timestamp";

--- a/capstone/src/main/java/com/google/sps/util/ProfileDatastoreUtil.java
+++ b/capstone/src/main/java/com/google/sps/util/ProfileDatastoreUtil.java
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.data;
+
+public final class ProfileDatastoreUtil {
+  public static final String PROFILE_TASK_NAME = "UserProfile";
+
+  public static final String IS_BUSINESS_PROPERTY = "isBusiness";
+  public static final String NAME_PROPERTY = "name";
+  public static final String LOCATION_PROPERTY = "location";
+  public static final String BIO_PROPERTY = "bio";
+  public static final String STORY_PROPERTY = "story";
+  public static final String ABOUT_PROPERTY = "about";
+  public static final String SUPPORT_PROPERTY = "support";
+  public static final String ANONYMOUS_NAME = "Anonymous";
+  public static final String NULL_STRING = "";
+  public static final String NO = "No";
+  public static final String YES = "Yes";
+}

--- a/capstone/src/test/java/com/google/sps/servlets/authentication/LoginServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/authentication/LoginServletTest.java
@@ -1,5 +1,22 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.servlets.authentication;
 
+import static com.google.sps.data.ProfileDatastoreUtil.IS_BUSINESS_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.NO;
+import static com.google.sps.data.ProfileDatastoreUtil.PROFILE_TASK_NAME;
 import static org.mockito.Mockito.when;
 
 import com.google.appengine.api.datastore.DatastoreService;
@@ -40,8 +57,6 @@ public class LoginServletTest {
   private static final String AUTHDOMAIN = "gmail.com";
   private static final String LOG_IN_URL = "/_ah/login?continue=%2Fcheck_new_user";
   private static final String LOG_OUT_URL = "/logout";
-  private static final String IS_BUSINESS_PROPERTY = "isBusiness";
-  private static final String NO = "No";
 
   @Mock private HttpServletRequest request;
 
@@ -88,9 +103,9 @@ public class LoginServletTest {
    **/
   @Test
   public void loggedInUserReturnsLogOutUrl() throws ServletException, IOException {
-    String keyString = KeyFactory.createKeyString("UserProfile", USER_ID);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, USER_ID);
     Key userKey = KeyFactory.stringToKey(keyString);
-    Entity ent = new Entity("UserProfile", USER_ID);
+    Entity ent = new Entity(PROFILE_TASK_NAME, USER_ID);
     ent.setProperty(IS_BUSINESS_PROPERTY, NO);
     datastore.put(ent);
 

--- a/capstone/src/test/java/com/google/sps/servlets/authentication/LogoutServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/authentication/LogoutServletTest.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.servlets.authentication;
 
 import static org.mockito.Mockito.verify;
@@ -5,7 +19,9 @@ import static org.mockito.Mockito.when;
 
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
-import java.io.*;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.List;
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;

--- a/capstone/src/test/java/com/google/sps/servlets/authentication/NewUserServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/authentication/NewUserServletTest.java
@@ -1,5 +1,27 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.servlets.authentication;
 
+import static com.google.sps.data.ProfileDatastoreUtil.ANONYMOUS_NAME;
+import static com.google.sps.data.ProfileDatastoreUtil.BIO_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.IS_BUSINESS_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.LOCATION_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.NAME_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.NO;
+import static com.google.sps.data.ProfileDatastoreUtil.NULL_STRING;
+import static com.google.sps.data.ProfileDatastoreUtil.PROFILE_TASK_NAME;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -24,21 +46,12 @@ import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public class NewUserServletTest {
-
-  private static final String IS_BUSINESS_PROPERTY = "isBusiness";
-  private static final String NAME_PROPERTY = "name";
-  private static final String LOCATION_PROPERTY = "location";
-  private static final String BIO_PROPERTY = "bio";
   private static final String NAME = "John Doe";
-  private static final String ANONYMOUS_NAME = "Anonymous";
   private static final String LOCATION = "Mountain View, CA";
   private static final String BIO = "This is my bio.";
   private static final String USER_ID = "12345";
   private static final String EMAIL = "abc@gmail.com";
   private static final String AUTHDOMAIN = "gmail.com";
-  private static final String DEFAULT = "";
-  private static final String YES = "Yes";
-  private static final String NO = "No";
 
   @Mock private HttpServletRequest request;
 
@@ -78,7 +91,7 @@ public class NewUserServletTest {
    **/
   @Test
   public void newUserAddToDatabase() throws Exception {
-    String keyString = KeyFactory.createKeyString("UserProfile", USER_ID);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, USER_ID);
     Key userKey = KeyFactory.stringToKey(keyString);
 
     newUserServlet.doGet(request, response);
@@ -86,8 +99,8 @@ public class NewUserServletTest {
     Entity capEntity = datastore.get(userKey);
     Assert.assertEquals(capEntity.getProperty(IS_BUSINESS_PROPERTY), NO);
     Assert.assertEquals(capEntity.getProperty(NAME_PROPERTY), ANONYMOUS_NAME);
-    Assert.assertEquals(capEntity.getProperty(LOCATION_PROPERTY), DEFAULT);
-    Assert.assertEquals(capEntity.getProperty(BIO_PROPERTY), DEFAULT);
+    Assert.assertEquals(capEntity.getProperty(LOCATION_PROPERTY), NULL_STRING);
+    Assert.assertEquals(capEntity.getProperty(BIO_PROPERTY), NULL_STRING);
   }
 
   /*
@@ -96,10 +109,10 @@ public class NewUserServletTest {
    **/
   @Test
   public void returningUserIsInDatabase() throws Exception {
-    String keyString = KeyFactory.createKeyString("UserProfile", USER_ID);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, USER_ID);
     Key userKey = KeyFactory.stringToKey(keyString);
 
-    Entity ent = new Entity("UserProfile", USER_ID);
+    Entity ent = new Entity(PROFILE_TASK_NAME, USER_ID);
     ent.setProperty(IS_BUSINESS_PROPERTY, NO);
     ent.setProperty(NAME_PROPERTY, NAME);
     ent.setProperty(LOCATION_PROPERTY, LOCATION);

--- a/capstone/src/test/java/com/google/sps/servlets/business/BusinessServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/business/BusinessServletTest.java
@@ -1,6 +1,22 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.servlets;
 
-import static org.mockito.Mockito.*;
+import static com.google.sps.data.ProfileDatastoreUtil.NO;
+import static com.google.sps.data.ProfileDatastoreUtil.PROFILE_TASK_NAME;
+import static com.google.sps.data.ProfileDatastoreUtil.YES;
 import static org.mockito.Mockito.when;
 
 import com.google.appengine.api.datastore.DatastoreService;
@@ -19,7 +35,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.sps.data.BusinessProfile;
-import java.io.*;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.HashMap;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -107,9 +125,9 @@ public class BusinessServletTest {
       throws ServletException, IOException, EntityNotFoundException {
     when(request.getPathInfo()).thenReturn(PATHINFO);
 
-    String keyString = KeyFactory.createKeyString("UserProfile", USER_ID);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, USER_ID);
     Key userKey = KeyFactory.stringToKey(keyString);
-    Entity ent = new Entity("UserProfile", USER_ID);
+    Entity ent = new Entity(PROFILE_TASK_NAME, USER_ID);
 
     userServlet.doGet(request, response);
 
@@ -126,11 +144,11 @@ public class BusinessServletTest {
       throws ServletException, IOException, EntityNotFoundException {
     when(request.getPathInfo()).thenReturn(PATHINFO);
 
-    String keyString = KeyFactory.createKeyString("UserProfile", USER_ID);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, USER_ID);
     Key userKey = KeyFactory.stringToKey(keyString);
     Entity ent = setUserProfileData();
 
-    String isBusiness = "No";
+    String isBusiness = NO;
     ent.setProperty("isBusiness", isBusiness);
 
     datastore.put(ent);
@@ -152,11 +170,11 @@ public class BusinessServletTest {
     when(response.getWriter()).thenReturn(printWriter);
     when(request.getPathInfo()).thenReturn(PATHINFO);
 
-    String keyString = KeyFactory.createKeyString("UserProfile", USER_ID);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, USER_ID);
     Key userKey = KeyFactory.stringToKey(keyString);
     Entity ent = setUserProfileData();
 
-    String isBusiness = "Yes";
+    String isBusiness = YES;
     boolean isCurrentUser = true;
     ent.setProperty("isBusiness", isBusiness);
 
@@ -203,7 +221,7 @@ public class BusinessServletTest {
   @Test
   public void editProfileNameNotFilledReturnError()
       throws ServletException, IOException, EntityNotFoundException {
-    String isBusiness = "Yes";
+    String isBusiness = YES;
 
     when(request.getParameter("isBusiness")).thenReturn(isBusiness);
     when(request.getParameter("name")).thenReturn(NO_NAME);
@@ -224,7 +242,7 @@ public class BusinessServletTest {
    **/
   @Test
   public void userEditProfileAddToDatastore() throws Exception {
-    String isBusiness = "Yes";
+    String isBusiness = YES;
 
     when(request.getParameter("isBusiness")).thenReturn(isBusiness);
     when(request.getParameter("name")).thenReturn(NAME);
@@ -236,7 +254,7 @@ public class BusinessServletTest {
 
     userServlet.doPost(request, response);
 
-    String keyString = KeyFactory.createKeyString("UserProfile", USER_ID);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, USER_ID);
     Key userKey = KeyFactory.stringToKey(keyString);
 
     Entity capEntity = datastore.get(userKey);
@@ -256,7 +274,7 @@ public class BusinessServletTest {
    **/
   @Test
   public void nonBusinessUserEditProfileAddToDatastore() throws Exception {
-    String isBusiness = "No";
+    String isBusiness = NO;
 
     when(request.getParameter("isBusiness")).thenReturn(isBusiness);
     when(request.getParameter("name")).thenReturn(NAME);
@@ -275,14 +293,14 @@ public class BusinessServletTest {
 
   // Create an entity with USERID.
   public Entity createUserProfile() {
-    String keyString = KeyFactory.createKeyString("UserProfile", USER_ID);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, USER_ID);
     Key userKey = KeyFactory.stringToKey(keyString);
-    return new Entity("UserProfile", USER_ID);
+    return new Entity(PROFILE_TASK_NAME, USER_ID);
   }
 
   // Set static variables to entity.
   public Entity setUserProfileData() {
-    Entity ent = new Entity("UserProfile", USER_ID);
+    Entity ent = new Entity(PROFILE_TASK_NAME, USER_ID);
     ent.setProperty("name", NAME);
     ent.setProperty("location", LOCATION);
     ent.setProperty("bio", BIO);

--- a/capstone/src/test/java/com/google/sps/servlets/business/BusinessesServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/business/BusinessesServletTest.java
@@ -14,6 +14,9 @@
 
 package com.google.sps.servlets;
 
+import static com.google.sps.data.ProfileDatastoreUtil.NO;
+import static com.google.sps.data.ProfileDatastoreUtil.PROFILE_TASK_NAME;
+import static com.google.sps.data.ProfileDatastoreUtil.YES;
 import static org.mockito.Mockito.doReturn;
 
 import com.google.appengine.api.datastore.DatastoreService;
@@ -24,7 +27,9 @@ import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.gson.Gson;
 import com.google.gson.JsonParser;
 import com.google.sps.data.BusinessProfile;
-import java.io.*;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
@@ -52,8 +57,7 @@ public class BusinessesServletTest {
 
   private static final String USER_ID_1 = "12345";
   private static final String USER_ID_2 = "6789";
-  private static final String NOT_A_BUSINESS = "No";
-  private static final String A_BUSINESS = "Yes";
+  private static final String A_BUSINESS = YES;
   private static final String NAME = "Pizzeria";
   private static final String LOCATION = "Mountain View, CA";
   private static final String BIO = "This is my business bio.";
@@ -100,7 +104,7 @@ public class BusinessesServletTest {
     datastore.put(aBusiness);
 
     Entity notABusiness = createBusiness(USER_ID_2);
-    notABusiness.setProperty("isBusiness", NOT_A_BUSINESS);
+    notABusiness.setProperty("isBusiness", NO);
     datastore.put(notABusiness);
 
     BusinessProfile businessProfile = createBusinessProfile(USER_ID_1);
@@ -119,7 +123,7 @@ public class BusinessesServletTest {
   }
 
   private Entity createBusiness(String id) {
-    Entity newBusiness = new Entity("UserProfile", id);
+    Entity newBusiness = new Entity(PROFILE_TASK_NAME, id);
     newBusiness.setProperty("name", NAME);
     newBusiness.setProperty("location", LOCATION);
     newBusiness.setProperty("bio", BIO);

--- a/capstone/src/test/java/com/google/sps/servlets/comments/CommentServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/comments/CommentServletTest.java
@@ -15,11 +15,11 @@
 package com.google.sps.servlets;
 
 import static com.google.appengine.api.datastore.FetchOptions.Builder.withLimit;
-import static com.google.sps.data.CommentDatastore.BUSINESS_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastore.COMMENT_ENTITY_NAME;
-import static com.google.sps.data.CommentDatastore.CONTENT_PROPERTY;
-import static com.google.sps.data.CommentDatastore.PARENT_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastore.USER_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.BUSINESS_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.COMMENT_TASK_NAME;
+import static com.google.sps.data.CommentDatastoreUtil.CONTENT_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.PARENT_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.USER_ID_PROPERTY;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
 
@@ -108,7 +108,7 @@ public class CommentServletTest {
   }
 
   private Query queryComment(String content, String userId, String businessId, String parentId) {
-    return new Query(COMMENT_ENTITY_NAME)
+    return new Query(COMMENT_TASK_NAME)
         .setFilter(
             new CompositeFilter(
                 CompositeFilterOperator.AND,

--- a/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
@@ -14,13 +14,13 @@
 
 package com.google.sps.servlets;
 
-import static com.google.sps.data.CommentDatastore.BUSINESS_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastore.COMMENT_ENTITY_NAME;
-import static com.google.sps.data.CommentDatastore.CONTENT_PROPERTY;
-import static com.google.sps.data.CommentDatastore.PARENT_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastore.TIMESTAMP_PROPERTY;
-import static com.google.sps.data.CommentDatastore.USER_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastore.generateComment;
+import static com.google.sps.data.CommentDatastoreUtil.BUSINESS_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.COMMENT_TASK_NAME;
+import static com.google.sps.data.CommentDatastoreUtil.CONTENT_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.PARENT_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.TIMESTAMP_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.USER_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.generateComment;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 
@@ -103,7 +103,7 @@ public class CommentsServletTest {
   }
 
   private Entity createCommentEntity(long timestamp, long userId, long businessId) {
-    Entity comment = new Entity(COMMENT_ENTITY_NAME);
+    Entity comment = new Entity(COMMENT_TASK_NAME);
 
     String id = "1" + timestamp + userId + businessId;
 

--- a/capstone/src/test/java/com/google/sps/servlets/profile/ProfileServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/profile/ProfileServletTest.java
@@ -1,5 +1,26 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.servlets.profile;
 
+import static com.google.sps.data.ProfileDatastoreUtil.BIO_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.IS_BUSINESS_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.LOCATION_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.NAME_PROPERTY;
+import static com.google.sps.data.ProfileDatastoreUtil.NO;
+import static com.google.sps.data.ProfileDatastoreUtil.PROFILE_TASK_NAME;
+import static com.google.sps.data.ProfileDatastoreUtil.YES;
 import static org.mockito.Mockito.when;
 
 import com.google.appengine.api.datastore.DatastoreService;
@@ -35,10 +56,6 @@ import org.mockito.MockitoAnnotations;
 @RunWith(JUnit4.class)
 public class ProfileServletTest {
 
-  private static final String NAME_PROPERTY = "name";
-  private static final String LOCATION_PROPERTY = "location";
-  private static final String BIO_PROPERTY = "bio";
-  private static final String IS_BUSINESS_PROPERTY = "isBusiness";
   private static final String NAME = "John Doe";
   private static final String NO_NAME = null;
   private static final String LOCATION = "Mountain View, CA";
@@ -49,8 +66,6 @@ public class ProfileServletTest {
   private static final String AUTHDOMAIN = "gmail.com";
   private static final String PATHINFO = "profile/12345";
   private static final String INVALID_PATHINFO = "profile";
-  private static final String YES = "Yes";
-  private static final String NO = "No";
 
   @Mock private HttpServletRequest request;
 
@@ -112,9 +127,9 @@ public class ProfileServletTest {
     when(request.getPathInfo()).thenReturn(PATHINFO);
 
     // Create an entity with this USER_ID.
-    String keyString = KeyFactory.createKeyString("UserProfile", USER_ID);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, USER_ID);
     Key userKey = KeyFactory.stringToKey(keyString);
-    Entity ent = new Entity("UserProfile", USER_ID);
+    Entity ent = new Entity(PROFILE_TASK_NAME, USER_ID);
 
     profileServlet.doGet(request, response);
 
@@ -130,10 +145,10 @@ public class ProfileServletTest {
   public void businessUserReturnError() throws Exception {
     when(request.getPathInfo()).thenReturn(PATHINFO);
 
-    // Create an entity with this USER_ID and set it's property "isBusiness" to "Yes".
+    // Create an entity with this USER_ID and set it's property "isBusiness" to YES.
     // Then add this to datastore.
-    Key userKey = KeyFactory.createKey("UserProfile", USER_ID);
-    Entity ent = new Entity("UserProfile", USER_ID);
+    Key userKey = KeyFactory.createKey(PROFILE_TASK_NAME, USER_ID);
+    Entity ent = new Entity(PROFILE_TASK_NAME, USER_ID);
 
     ent.setProperty(IS_BUSINESS_PROPERTY, YES);
     ent.setProperty(NAME_PROPERTY, NAME);
@@ -157,10 +172,10 @@ public class ProfileServletTest {
     when(response.getWriter()).thenReturn(printWriter);
     when(request.getPathInfo()).thenReturn(PATHINFO);
 
-    // Create an entity with this USER_ID and set it's property "isBusiness" to "No".
+    // Create an entity with this USER_ID and set it's property "isBusiness" to NO.
     // Then add this to datastore.
-    Key userKey = KeyFactory.createKey("UserProfile", USER_ID);
-    Entity ent = new Entity("UserProfile", USER_ID);
+    Key userKey = KeyFactory.createKey(PROFILE_TASK_NAME, USER_ID);
+    Entity ent = new Entity(PROFILE_TASK_NAME, USER_ID);
 
     boolean isCurrentUser = true;
 
@@ -220,8 +235,8 @@ public class ProfileServletTest {
     when(request.getParameter(LOCATION_PROPERTY)).thenReturn(LOCATION);
     when(request.getParameter(BIO_PROPERTY)).thenReturn(BIO);
 
-    Key userKey = KeyFactory.createKey("UserProfile", USER_ID);
-    Entity ent = new Entity("UserProfile", USER_ID);
+    Key userKey = KeyFactory.createKey(PROFILE_TASK_NAME, USER_ID);
+    Entity ent = new Entity(PROFILE_TASK_NAME, USER_ID);
 
     profileServlet.doPost(request, response);
 
@@ -242,7 +257,7 @@ public class ProfileServletTest {
 
     profileServlet.doPost(request, response);
 
-    String keyString = KeyFactory.createKeyString("UserProfile", USER_ID);
+    String keyString = KeyFactory.createKeyString(PROFILE_TASK_NAME, USER_ID);
     Key userKey = KeyFactory.stringToKey(keyString);
 
     Entity capEntity = datastore.get(userKey);


### PR DESCRIPTION
This PR includes the following refactorings
- Move `BusinessServlet.java` and `BusinessesServlet.java` into `business` directory like we did with the other servlets
- Put a license at the top of the `.java` files that didn't yet have one b.c. Google doesn't want to get sued
- Create `ProfileDatastore.java` that contains `public static final` variables for various names associated with the `UserProfile` Datastore and replace mentions of these strings with static imports of those variables. This was done for improved consistency.