### PR TITLE
Fix uncaught bugs in Comment and Comments Servlet

### DIFF
--- a/capstone/src/main/java/com/google/sps/data/Comment.java
+++ b/capstone/src/main/java/com/google/sps/data/Comment.java
@@ -39,33 +39,14 @@ public final class Comment {
   private final boolean hasReplies;
   private final String timestampStr;
 
-  public Comment(
+  public Comment (
       String id,
       String content,
       long timestamp,
       String userId,
       String name,
       String businessId,
-      String parentId) {
-    this.id = id;
-    this.content = content;
-    this.timestamp = timestamp;
-    this.userId = userId;
-    this.name = name;
-    this.businessId = businessId;
-    this.parentId = parentId;
-    this.hasReplies = false;
-    // Epoch timestamp is formatted in UTC time
-    this.timestampStr = new SimpleDateFormat("MM/dd/yy HH:mm").format(timestamp);
-  }
-
-  public Comment(
-      String id,
-      String content,
-      long timestamp,
-      String userId,
-      String name,
-      String businessId,
+      String parentId,
       boolean hasReplies) {
     this.id = id;
     this.content = content;
@@ -73,7 +54,7 @@ public final class Comment {
     this.userId = userId;
     this.name = name;
     this.businessId = businessId;
-    this.parentId = "";
+    this.parentId = parentId;
     this.hasReplies = hasReplies;
     // Epoch timestamp is formatted in UTC time
     this.timestampStr = new SimpleDateFormat("MM/dd/yy HH:mm").format(timestamp);

--- a/capstone/src/main/java/com/google/sps/data/Comment.java
+++ b/capstone/src/main/java/com/google/sps/data/Comment.java
@@ -74,7 +74,7 @@ public final class Comment {
     this.name = name;
     this.businessId = businessId;
     this.parentId = "";
-    this.hasReplies = false;
+    this.hasReplies = hasReplies;
     // Epoch timestamp is formatted in UTC time
     this.timestampStr = new SimpleDateFormat("MM/dd/yy HH:mm").format(timestamp);
   }

--- a/capstone/src/main/java/com/google/sps/data/Comment.java
+++ b/capstone/src/main/java/com/google/sps/data/Comment.java
@@ -39,7 +39,7 @@ public final class Comment {
   private final boolean hasReplies;
   private final String timestampStr;
 
-  public Comment (
+  public Comment(
       String id,
       String content,
       long timestamp,

--- a/capstone/src/main/java/com/google/sps/data/Comment.java
+++ b/capstone/src/main/java/com/google/sps/data/Comment.java
@@ -15,6 +15,7 @@
 package com.google.sps.data;
 
 import java.text.SimpleDateFormat;
+import java.lang.IllegalArgumentException;
 
 public final class Comment {
   /**
@@ -47,7 +48,10 @@ public final class Comment {
       String name,
       String businessId,
       String parentId,
-      boolean hasReplies) {
+      boolean hasReplies) throws IllegalArgumentException {
+    if (hasReplies && !parentId.isEmpty()) {
+      throw new IllegalArgumentException("A reply comment cannot have it's own replies.");
+    }
     this.id = id;
     this.content = content;
     this.timestamp = timestamp;

--- a/capstone/src/main/java/com/google/sps/servlets/comments/CommentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/comments/CommentServlet.java
@@ -75,12 +75,15 @@ public class CommentServlet extends HttpServlet {
 
     if (!isNullOrEmpty(parentId)) {
       try {
-        Entity parentEntity = datastore.get(KeyFactory.createKey(COMMENT_TASK_NAME, parentId));
+        Entity parentEntity = datastore.get(KeyFactory.stringToKey(parentId));
         parentEntity.setProperty(HAS_REPLIES_PROPERTY, true);
         datastore.put(parentEntity);
       } catch (EntityNotFoundException e) {
         response.sendError(
-            HttpServletResponse.SC_BAD_REQUEST, "Cannot post replies to non-existent comments.");
+            HttpServletResponse.SC_BAD_REQUEST, "The parentId \'" + parentId + "\' does not exist in the datastore. Cannot post replies to non-existent comments.");
+        return;
+      } catch (IllegalArgumentException e) {
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST, "The parentId you specified is invalid");
         return;
       }
     }

--- a/capstone/src/main/java/com/google/sps/servlets/comments/CommentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/comments/CommentServlet.java
@@ -80,10 +80,15 @@ public class CommentServlet extends HttpServlet {
         datastore.put(parentEntity);
       } catch (EntityNotFoundException e) {
         response.sendError(
-            HttpServletResponse.SC_BAD_REQUEST, "The parentId \'" + parentId + "\' does not exist in the datastore. Cannot post replies to non-existent comments.");
+            HttpServletResponse.SC_BAD_REQUEST,
+            "The parentId \'"
+                + parentId
+                + "\' does not exist in the datastore. Cannot post replies to non-existent"
+                + " comments.");
         return;
       } catch (IllegalArgumentException e) {
-        response.sendError(HttpServletResponse.SC_BAD_REQUEST, "The parentId you specified is invalid");
+        response.sendError(
+            HttpServletResponse.SC_BAD_REQUEST, "The parentId you specified is invalid");
         return;
       }
     }

--- a/capstone/src/main/java/com/google/sps/util/CommentDatastoreUtil.java
+++ b/capstone/src/main/java/com/google/sps/util/CommentDatastoreUtil.java
@@ -43,13 +43,8 @@ public final class CommentDatastoreUtil {
     String name = getProfileName(userId, datastore);
     String businessId = (String) commentEntity.getProperty(BUSINESS_ID_PROPERTY);
     String parentId = (String) commentEntity.getProperty(PARENT_ID_PROPERTY);
-
-    // Use two different constructors depending on whether the comment is a reply or not
-    if (parentId.isEmpty()) {
-      boolean hasReplies = (boolean) commentEntity.getProperty(HAS_REPLIES_PROPERTY);
-      return new Comment(id, content, timestamp, userId, name, businessId, hasReplies);
-    } else {
-      return new Comment(id, content, timestamp, userId, name, businessId, parentId);
-    }
+    boolean hasReplies = (boolean) commentEntity.getProperty(HAS_REPLIES_PROPERTY);
+  
+    return new Comment(id, content, timestamp, userId, name, businessId, parentId, hasReplies);
   }
 }

--- a/capstone/src/main/java/com/google/sps/util/CommentDatastoreUtil.java
+++ b/capstone/src/main/java/com/google/sps/util/CommentDatastoreUtil.java
@@ -44,7 +44,7 @@ public final class CommentDatastoreUtil {
     String businessId = (String) commentEntity.getProperty(BUSINESS_ID_PROPERTY);
     String parentId = (String) commentEntity.getProperty(PARENT_ID_PROPERTY);
     boolean hasReplies = (boolean) commentEntity.getProperty(HAS_REPLIES_PROPERTY);
-  
+
     return new Comment(id, content, timestamp, userId, name, businessId, parentId, hasReplies);
   }
 }

--- a/capstone/src/main/java/com/google/sps/util/CommentDatastoreUtil.java
+++ b/capstone/src/main/java/com/google/sps/util/CommentDatastoreUtil.java
@@ -30,6 +30,8 @@ public final class CommentDatastoreUtil {
   public static final String PARENT_ID_PROPERTY = "parentId";
   public static final String HAS_REPLIES_PROPERTY = "hasReplies";
 
+  public static final String NULL_ID = "";
+
   public static Comment generateComment(Entity commentEntity, DatastoreService datastore) {
     String id;
     if (commentEntity.getKey().getName() != null) {

--- a/capstone/src/main/java/com/google/sps/util/CommentDatastoreUtil.java
+++ b/capstone/src/main/java/com/google/sps/util/CommentDatastoreUtil.java
@@ -43,8 +43,13 @@ public final class CommentDatastoreUtil {
     String name = getProfileName(userId, datastore);
     String businessId = (String) commentEntity.getProperty(BUSINESS_ID_PROPERTY);
     String parentId = (String) commentEntity.getProperty(PARENT_ID_PROPERTY);
-    boolean hasReplies = (boolean) commentEntity.getProperty(HAS_REPLIES_PROPERTY);
 
-    return new Comment(id, content, timestamp, userId, name, businessId, parentId);
+    // Use two different constructors depending on whether the comment is a reply or not
+    if (parentId.isEmpty()) {
+      boolean hasReplies = (boolean) commentEntity.getProperty(HAS_REPLIES_PROPERTY);
+      return new Comment(id, content, timestamp, userId, name, businessId, hasReplies);
+    } else {
+      return new Comment(id, content, timestamp, userId, name, businessId, parentId);
+    }
   }
 }

--- a/capstone/src/test/java/com/google/sps/servlets/comments/CommentServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/comments/CommentServletTest.java
@@ -22,15 +22,15 @@ import static com.google.sps.data.CommentDatastoreUtil.HAS_REPLIES_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.PARENT_ID_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.USER_ID_PROPERTY;
 import static com.google.sps.util.CommentTestUtil.createCommentEntity;
-import static com.google.sps.util.CommentTestUtil.generateUniqueCommentId;
 import static com.google.sps.util.TestUtil.assertResponseWithArbitraryTextRaised;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.CompositeFilter;
 import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
@@ -41,7 +41,6 @@ import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
-import com.google.appengine.api.datastore.EntityNotFoundException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -222,12 +221,13 @@ public class CommentServletTest {
   }
 
   @Test
-  public void testPostingCommentChangesHasRepliesField() throws IOException, EntityNotFoundException {
+  public void testPostingCommentChangesHasRepliesField()
+      throws IOException, EntityNotFoundException {
     // Add parent comment
 
-    Entity parentCommentEntity = 
+    Entity parentCommentEntity =
         createCommentEntity(/*Timestamp*/ 1, MOCK_USER_ID, MOCK_BUSINESS_ID, false);
-    
+
     ds.put(parentCommentEntity);
 
     String parentId = KeyFactory.keyToString(parentCommentEntity.getKey());
@@ -240,7 +240,6 @@ public class CommentServletTest {
     servlet.doPost(request, response);
 
     assertEquals(true, ds.get(KeyFactory.stringToKey(parentId)).getProperty(HAS_REPLIES_PROPERTY));
-
   }
 
   @Test

--- a/capstone/src/test/java/com/google/sps/servlets/comments/CommentServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/comments/CommentServletTest.java
@@ -19,9 +19,9 @@ import static com.google.sps.data.CommentDatastoreUtil.BUSINESS_ID_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.COMMENT_TASK_NAME;
 import static com.google.sps.data.CommentDatastoreUtil.CONTENT_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.HAS_REPLIES_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.NULL_ID;
 import static com.google.sps.data.CommentDatastoreUtil.PARENT_ID_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.USER_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastoreUtil.NULL_ID;
 import static com.google.sps.util.CommentTestUtil.createCommentEntity;
 import static com.google.sps.util.TestUtil.assertResponseWithArbitraryTextRaised;
 import static org.junit.Assert.assertEquals;
@@ -133,12 +133,14 @@ public class CommentServletTest {
   @Test
   public void testBasicDoPost() throws IOException {
     assertEquals(
-        0, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
+        0,
+        countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
 
     servlet.doPost(request, response);
 
     assertEquals(
-        1, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
+        1,
+        countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
   }
 
   // Make sure that when we add two comments with the same properties we still save two seperate
@@ -146,13 +148,15 @@ public class CommentServletTest {
   @Test
   public void testSameCommentTwice() throws IOException {
     assertEquals(
-        0, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
+        0,
+        countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
 
     servlet.doPost(request, response);
     servlet.doPost(request, response);
 
     assertEquals(
-        2, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
+        2,
+        countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
   }
 
   // Make requests where one parameter is missing, we expect that to lead to an error
@@ -201,7 +205,8 @@ public class CommentServletTest {
     servlet.doPost(request, response);
 
     assertEquals(
-        1, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
+        1,
+        countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
   }
 
   @Test
@@ -268,13 +273,15 @@ public class CommentServletTest {
   @Test
   public void testPostParentIdEmptyString() throws IOException {
     assertEquals(
-        0, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
+        0,
+        countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
 
     doReturn(NULL_ID).when(request).getParameter(PARENT_ID_PROPERTY);
 
     servlet.doPost(request, response);
 
     assertEquals(
-        1, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
+        1,
+        countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
   }
 }

--- a/capstone/src/test/java/com/google/sps/servlets/comments/CommentServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/comments/CommentServletTest.java
@@ -21,6 +21,7 @@ import static com.google.sps.data.CommentDatastoreUtil.CONTENT_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.HAS_REPLIES_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.PARENT_ID_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.USER_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.NULL_ID;
 import static com.google.sps.util.CommentTestUtil.createCommentEntity;
 import static com.google.sps.util.TestUtil.assertResponseWithArbitraryTextRaised;
 import static org.junit.Assert.assertEquals;
@@ -132,12 +133,12 @@ public class CommentServletTest {
   @Test
   public void testBasicDoPost() throws IOException {
     assertEquals(
-        0, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, "", false));
+        0, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
 
     servlet.doPost(request, response);
 
     assertEquals(
-        1, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, "", false));
+        1, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
   }
 
   // Make sure that when we add two comments with the same properties we still save two seperate
@@ -145,13 +146,13 @@ public class CommentServletTest {
   @Test
   public void testSameCommentTwice() throws IOException {
     assertEquals(
-        0, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, "", false));
+        0, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
 
     servlet.doPost(request, response);
     servlet.doPost(request, response);
 
     assertEquals(
-        2, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, "", false));
+        2, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
   }
 
   // Make requests where one parameter is missing, we expect that to lead to an error
@@ -200,7 +201,7 @@ public class CommentServletTest {
     servlet.doPost(request, response);
 
     assertEquals(
-        1, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, "", false));
+        1, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
   }
 
   @Test
@@ -267,13 +268,13 @@ public class CommentServletTest {
   @Test
   public void testPostParentIdEmptyString() throws IOException {
     assertEquals(
-        0, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, "", false));
+        0, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
 
-    doReturn("").when(request).getParameter(PARENT_ID_PROPERTY);
+    doReturn(NULL_ID).when(request).getParameter(PARENT_ID_PROPERTY);
 
     servlet.doPost(request, response);
 
     assertEquals(
-        1, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, "", false));
+        1, countCommentOccurences(ds, MOCK_CONTENT, MOCK_USER_ID, MOCK_BUSINESS_ID, NULL_ID, false));
   }
 }

--- a/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
@@ -161,14 +161,29 @@ public class CommentsServletTest {
       long timestamp, String userId, String businessId, boolean hasReplies) {
     String id = generateUniqueCommentId(timestamp, userId, businessId);
     return new Comment(
-        id, id, timestamp, userId, getProfileName(userId, ds), businessId, /*parentId*/ "", hasReplies);
+        id,
+        id,
+        timestamp,
+        userId,
+        getProfileName(userId, ds),
+        businessId, /*parentId*/
+        "",
+        hasReplies);
   }
 
   private Comment generateCommentForTest(
       long timestamp, String userId, String businessId, String parentId) {
     String id = generateUniqueCommentId(timestamp, userId, businessId);
 
-    return new Comment(id, id, timestamp, userId, getProfileName(userId, ds), businessId, parentId, /*hasReplies*/ false);
+    return new Comment(
+        id,
+        id,
+        timestamp,
+        userId,
+        getProfileName(userId, ds),
+        businessId,
+        parentId, /*hasReplies*/
+        false);
   }
 
   /** Assert that the response by the server was just an empty JSON object */

--- a/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
@@ -17,6 +17,7 @@ package com.google.sps.servlets;
 import static com.google.sps.data.CommentDatastoreUtil.BUSINESS_ID_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.PARENT_ID_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.USER_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.NULL_ID;
 import static com.google.sps.data.ProfileDatastoreUtil.NAME_PROPERTY;
 import static com.google.sps.data.ProfileDatastoreUtil.PROFILE_TASK_NAME;
 import static com.google.sps.data.ProfileDatastoreUtil.getProfileName;
@@ -167,7 +168,7 @@ public class CommentsServletTest {
         userId,
         getProfileName(userId, ds),
         businessId, /*parentId*/
-        "",
+        NULL_ID,
         hasReplies);
   }
 

--- a/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
@@ -53,6 +53,7 @@ public class CommentsServletTest {
   private final String BUSINESS_ID_1 = "1";
   private final String USER_NAME_0 = "User 0";
   private final String USER_NAME_1 = "User 1";
+  private final long TIMESTAMP_0 = 0;
 
   private final LocalServiceTestHelper helper =
       new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
@@ -232,7 +233,7 @@ public class CommentsServletTest {
 
     Comment[] expectedReturnedComments =
         new Comment[] {
-          generateCommentForTest(/*timestamp*/ (long) 3, USER_ID_1, BUSINESS_ID_0, false),
+          generateCommentForTest(/*timestamp*/ (long) 3, USER_ID_1, BUSINESS_ID_0, true),
           generateCommentForTest(/*timestamp*/ 0, USER_ID_0, BUSINESS_ID_0, true),
         };
 
@@ -331,20 +332,15 @@ public class CommentsServletTest {
 
   @Test
   public void testShowsUserName() throws IOException {
-    long timestamp = 0;
-    String userId = "33";
-    String username = "Larry";
-    String businessId = "0";
+    ds.put(createProfileEntity(USER_ID_0, USER_ID_0));
+    ds.put(createCommentEntity(TIMESTAMP_0, USER_ID_0, BUSINESS_ID_0, /*hasReplies*/ false));
 
-    ds.put(createProfileEntity(userId, username));
-    ds.put(createCommentEntity(/*timestamp*/ 0, userId, /*businessId*/ businessId, false));
-
-    doReturn(userId).when(request).getParameter(USER_ID_PROPERTY);
+    doReturn(USER_ID_0).when(request).getParameter(USER_ID_PROPERTY);
 
     servlet.doGet(request, response);
     String servletResponse = servletResponseWriter.toString();
 
-    Comment expectedRetrievedComment = generateCommentForTest(0, userId, businessId, false);
+    Comment expectedRetrievedComment = generateCommentForTest(0, USER_ID_0, BUSINESS_ID_0, /*hasReplies*/ false);
     String expectedResponse = new Gson().toJson(new Comment[] {expectedRetrievedComment});
 
     assertSameJsonObject(expectedResponse, servletResponse);

--- a/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
@@ -15,9 +15,9 @@
 package com.google.sps.servlets;
 
 import static com.google.sps.data.CommentDatastoreUtil.BUSINESS_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.NULL_ID;
 import static com.google.sps.data.CommentDatastoreUtil.PARENT_ID_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.USER_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastoreUtil.NULL_ID;
 import static com.google.sps.data.ProfileDatastoreUtil.NAME_PROPERTY;
 import static com.google.sps.data.ProfileDatastoreUtil.PROFILE_TASK_NAME;
 import static com.google.sps.data.ProfileDatastoreUtil.getProfileName;

--- a/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
@@ -340,7 +340,8 @@ public class CommentsServletTest {
     servlet.doGet(request, response);
     String servletResponse = servletResponseWriter.toString();
 
-    Comment expectedRetrievedComment = generateCommentForTest(0, USER_ID_0, BUSINESS_ID_0, /*hasReplies*/ false);
+    Comment expectedRetrievedComment =
+        generateCommentForTest(0, USER_ID_0, BUSINESS_ID_0, /*hasReplies*/ false);
     String expectedResponse = new Gson().toJson(new Comment[] {expectedRetrievedComment});
 
     assertSameJsonObject(expectedResponse, servletResponse);

--- a/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
@@ -161,14 +161,14 @@ public class CommentsServletTest {
       long timestamp, String userId, String businessId, boolean hasReplies) {
     String id = generateUniqueCommentId(timestamp, userId, businessId);
     return new Comment(
-        id, id, timestamp, userId, getProfileName(userId, ds), businessId, hasReplies);
+        id, id, timestamp, userId, getProfileName(userId, ds), businessId, /*parentId*/ "", hasReplies);
   }
 
   private Comment generateCommentForTest(
       long timestamp, String userId, String businessId, String parentId) {
     String id = generateUniqueCommentId(timestamp, userId, businessId);
 
-    return new Comment(id, id, timestamp, userId, getProfileName(userId, ds), businessId, parentId);
+    return new Comment(id, id, timestamp, userId, getProfileName(userId, ds), businessId, parentId, /*hasReplies*/ false);
   }
 
   /** Assert that the response by the server was just an empty JSON object */

--- a/capstone/src/test/java/com/google/sps/util/CommentTestUtil.java
+++ b/capstone/src/test/java/com/google/sps/util/CommentTestUtil.java
@@ -18,10 +18,10 @@ import static com.google.sps.data.CommentDatastoreUtil.BUSINESS_ID_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.COMMENT_TASK_NAME;
 import static com.google.sps.data.CommentDatastoreUtil.CONTENT_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.HAS_REPLIES_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.NULL_ID;
 import static com.google.sps.data.CommentDatastoreUtil.PARENT_ID_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.TIMESTAMP_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.USER_ID_PROPERTY;
-import static com.google.sps.data.CommentDatastoreUtil.NULL_ID;
 
 import com.google.appengine.api.datastore.Entity;
 

--- a/capstone/src/test/java/com/google/sps/util/CommentTestUtil.java
+++ b/capstone/src/test/java/com/google/sps/util/CommentTestUtil.java
@@ -21,13 +21,14 @@ import static com.google.sps.data.CommentDatastoreUtil.HAS_REPLIES_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.PARENT_ID_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.TIMESTAMP_PROPERTY;
 import static com.google.sps.data.CommentDatastoreUtil.USER_ID_PROPERTY;
+import static com.google.sps.data.CommentDatastoreUtil.NULL_ID;
 
 import com.google.appengine.api.datastore.Entity;
 
 public class CommentTestUtil {
   public static Entity createCommentEntity(
       long timestamp, String userId, String businessId, boolean hasReplies) {
-    Entity commentEntity = createCommentEntity(timestamp, userId, businessId, "");
+    Entity commentEntity = createCommentEntity(timestamp, userId, businessId, NULL_ID);
 
     commentEntity.setProperty(HAS_REPLIES_PROPERTY, hasReplies);
 


### PR DESCRIPTION
The first bug was that when a name wasn't speficied for a comment but instead a random id was generated, the Comment Servlet was not able to retrieve comments to update their `hasReplies` property. 

The bug wasn't caught because in order to reference comments more easily in testing, we were manually assigning names to them. This was changed in CommentServletTest.java.

The second bug was that when a comment was generated the `hasReplies` property was always set to `false` even if it was `true`. 

This bug wasn't caught because the `generateTestComment` function ignored the `hasReplies` field and would just generate a test comment with the `hasReplies` field always set to zero, so the expected results matched the actual results because they were both wrong in the same way.