### PR TITLE
Change sort direction of comment replies to ascending

### DIFF
--- a/capstone/src/main/java/com/google/sps/servlets/comments/CommentsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/comments/CommentsServlet.java
@@ -111,7 +111,7 @@ public class CommentsServlet extends HttpServlet {
     } else {
       sortDirection = SortDirection.DESCENDING;
     }
-    
+
     Query query =
         new Query(COMMENT_TASK_NAME)
             .setFilter(buildFilter(filterProperty, filterValue))

--- a/capstone/src/main/java/com/google/sps/servlets/comments/CommentsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/comments/CommentsServlet.java
@@ -104,10 +104,18 @@ public class CommentsServlet extends HttpServlet {
 
   private List<Entity> runCommentsQuery(String filterProperty, String filterValue)
       throws IllegalArgumentException {
+    SortDirection sortDirection;
+    if (filterProperty.equals(PARENT_ID_PROPERTY)) {
+      // Sort replies by oldest first
+      sortDirection = SortDirection.ASCENDING;
+    } else {
+      sortDirection = SortDirection.DESCENDING;
+    }
+    
     Query query =
         new Query(COMMENT_TASK_NAME)
             .setFilter(buildFilter(filterProperty, filterValue))
-            .addSort(TIMESTAMP_PROPERTY, SortDirection.DESCENDING);
+            .addSort(TIMESTAMP_PROPERTY, sortDirection);
     return datastore.prepare(query).asList(FetchOptions.Builder.withLimit(COMMENT_LIMIT));
   }
 

--- a/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/comments/CommentsServletTest.java
@@ -299,10 +299,11 @@ public class CommentsServletTest {
 
     Comment[] expectedReturnedComments =
         new Comment[] {
-          generateCommentForTest(
-              /*timestamp*/ 2, USER_ID_1, BUSINESS_ID_0, /*parentId*/ parameterVal),
+          // Replies sorted in reverse order
           generateCommentForTest(
               /*timestamp*/ 1, USER_ID_0, BUSINESS_ID_0, /*parentId*/ parameterVal),
+          generateCommentForTest(
+              /*timestamp*/ 2, USER_ID_1, BUSINESS_ID_0, /*parentId*/ parameterVal),
         };
 
     runTest(parameterName, parameterVal, expectedReturnedComments);


### PR DESCRIPTION
With this change, replies are shown in the standard way, where newer replies are at the bottom and older ones are at the top.