### PR TITLE
Fix issue with show more not working on search results.

### DIFF
--- a/capstone/src/main/webapp/index.html
+++ b/capstone/src/main/webapp/index.html
@@ -41,9 +41,9 @@
         </div>
         <!-- List of Business Cards -->
         <div id="businesses">
-          <div id="followed-businesses"></div>
-          <div id="other-businesses"></div>
           <div id="result-businesses"></div>
+          <div id="followed-businesses"></div>
+          <div id="other-businesses"></div
         </div>
       </div>
 


### PR DESCRIPTION
Originally, search results were not able to have the about description expanded since there are multiple ids. Even though the other two divs were hidden, the ids were still "active" and those were being read first. By moving the results div first, it would ensure that these ids are read first.